### PR TITLE
MRIID-33 Fixed issue with 'Total outbreak projections' in Sidebar.

### DIFF
--- a/src/utils/__tests__/ebolaDataHelpers.test.js
+++ b/src/utils/__tests__/ebolaDataHelpers.test.js
@@ -52,6 +52,18 @@ describe("Tests for getEbolaCountriesCaseCounts", () => {
       )
     ).toEqual({ Guinea: 126, Liberia: 0, "Sierra Leone": 126 });
   });
+  test("when projections are enabled, get the case count from projections.fourWeeks", () => {
+    const projectionsEnabledState = {
+      ...reduxInitialState,
+      filters: { ...reduxInitialState.filters, projection: true },
+    };
+    expect(
+      getEbolaCountriesCaseCounts(
+        allCountriesEbolaData,
+        projectionsEnabledState.filters
+      )
+    ).toEqual({ Guinea: 296, Liberia: 296, "Sierra Leone": 296 });
+  });
 });
 
 describe("Tests for getDiseaseCaseCount", () => {

--- a/src/utils/ebolaDataHelpers.js
+++ b/src/utils/ebolaDataHelpers.js
@@ -55,7 +55,14 @@ export const getEbolaCountriesCaseCounts = (ebolaData, filters) => {
         // If so, add that count to the countryCaseCount object for the country.
         if (isDateWithinFiltersDateRange(weekDateKey, filters.dateRange)) {
           const weeklyEbolaData = countryEbolaData[weekDateKey];
-          countryCaseCount[country] += parseInt(weeklyEbolaData.value);
+          // if projections are enabled, the count we want is the 'fourWeeks' projections count.
+          if (filters.projection) {
+            countryCaseCount[country] += parseInt(
+              weeklyEbolaData.projections.fourWeeks
+            );
+          } else {
+            countryCaseCount[country] += parseInt(weeklyEbolaData.value);
+          }
         }
       });
     }


### PR DESCRIPTION
Fixed an issue with the count under 'Total outbreak projections' in Sidebar. This counter remained the same when `projections` were enabled/disabled. Updated the projections count to be the same as the current prod MRIIDS site (http://mriids.org/).

![Screen Shot 2020-11-18 at 11 15 05 AM](https://user-images.githubusercontent.com/40768918/99556283-5353e000-298f-11eb-9d6a-fa89a80652b9.png)
