### PR TITLE
Removed COVID 19 option from SideBar for now

### DIFF
--- a/src/components/Sidebar/__tests__/__snapshots__/Sidebar.test.js.snap
+++ b/src/components/Sidebar/__tests__/__snapshots__/Sidebar.test.js.snap
@@ -136,11 +136,6 @@ exports[`Tests for the connected Sidebar component with reduxInitialState should
       >
         Ebola Outbreak
       </option>
-      <option
-        value="COVID 19"
-      >
-        COVID 19
-      </option>
     </select>
   </div>
   <div
@@ -318,11 +313,6 @@ exports[`Tests for the connected Sidebar component with riskViewState should ren
         value="Ebola Outbreak"
       >
         Ebola Outbreak
-      </option>
-      <option
-        value="COVID 19"
-      >
-        COVID 19
       </option>
     </select>
   </div>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -61,7 +61,7 @@ const Sidebar = ({
         <Select
           name="outbreak"
           type="outbreak"
-          options={["Ebola Outbreak", "COVID 19"]}
+          options={["Ebola Outbreak"]}
           value={filters.outbreak}
           changeFunction={changeOutbreak}
         />

--- a/src/components/styled-components/LogoGroup.js
+++ b/src/components/styled-components/LogoGroup.js
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { media } from "../../assets/style-utils";
 
 export const ContentWrapper = styled.div`
   max-width: 1400px;


### PR DESCRIPTION
Removed "COVID 19" option from `SideBar` component for now since we haven't added the covid data yet. Will re-add it once we have done the first deployment. 

Also removed an unused import from `src/components/styled-components/LogoGroup.js` 