### PR TITLE
updated position of legend and size of risk map

### DIFF
--- a/src/components/SnapshotMapCaseCountLegend/__tests__/__snapshots__/SnapshotMapCaseCountLegend.test.js.snap
+++ b/src/components/SnapshotMapCaseCountLegend/__tests__/__snapshots__/SnapshotMapCaseCountLegend.test.js.snap
@@ -31,15 +31,13 @@ exports[`Tests for the connected SnapshotMapCaseCountLegend component with redux
 
 .c0 {
   position: absolute;
-  top: 2rem;
   left: 2rem;
-  bottom: 7rem;
+  bottom: 3.2rem;
   width: 9rem;
 }
 
 .c0 > div {
   width: 100%;
-  height: 75%;
 }
 
 .c2 {

--- a/src/components/styled-components/MapContainers.js
+++ b/src/components/styled-components/MapContainers.js
@@ -12,6 +12,6 @@ export const EbolaRiskMapContainer = styled.div`
   flex: none;
   position: relative;
   padding-left: ${(props) => props.theme.sidebarWidth};
-  height: 85rem; /* $risk-height */
+  height: calc(100vh - 5.6rem); 
   overflow: hidden;
 `;

--- a/src/components/styled-components/MapLegendWrappers.js
+++ b/src/components/styled-components/MapLegendWrappers.js
@@ -5,23 +5,20 @@ export const MapLegendWrapperRisk = styled.div`
   padding-left: ${(props) => props.theme.sidebarWidth};
   width: 9rem;
   left: 2rem;
-  bottom: 7rem;
+  bottom: 3.2rem;
   > div {
     width: 100%;
-    height: 100%;
   }
 `;
 
 export const MapLegendWrapperSnapshot = styled.div`
   position: absolute;
   padding-left: ${(props) => props.theme.sidebarWidth};
-  top: 2rem;
   left: 2rem;
-  bottom: 7rem;
+  bottom: 3.2rem;
   width: 9rem;
   > div {
     width: 100%;
-    height: 75%;
   }
 `;
 

--- a/src/components/styled-components/ZoomButtons.js
+++ b/src/components/styled-components/ZoomButtons.js
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const ZoomButtons = styled.div`
   position: absolute;
   right: 10px;
-  bottom: 40px;
+  bottom: 3.2rem;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
- Updated position of legend on risk map and snapshot map so they are in the same position on both maps
- Updated size of risk map so it fits on all screen sizes

To test this:
1) Go to http://localhost:3000/ and view the snapshot map and confirm that the legend and zoom controls are visible 
2) Click on the risk map and confirm that the legend and zoom controls are visible 

![image](https://user-images.githubusercontent.com/4304814/100134285-f99f5a00-2e55-11eb-8ed5-aa29edc899ea.png)
![image](https://user-images.githubusercontent.com/4304814/100134306-0328c200-2e56-11eb-8a97-a7acf869fca3.png)

