### PR TITLE
MRIID-41 Covid Date Range

### DIFF
--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -1,18 +1,30 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { changeDateRange } from "../../actions/filters";
 import { Slider } from "@material-ui/core";
 import Timespan from "../Timespan";
 import ProjectionsToggle from "../ProjectionsToggle";
-import { ebolaInitialDateRange } from "../../constants/DateRanges";
+import {
+  ebolaInitialDateRange,
+  covidInitialDateRange,
+} from "../../constants/DateRanges";
 import {
   DateRangeComponentContainer,
   DateRangeSliderContainer,
 } from "../styled-components/DateRangeComponentContainer";
 
-const DateRange = (props) => {
+const DateRange = ({ filters, changeDateRange }) => {
   const [sliderRange, setSliderRange] = useState([0, 72]);
+
+  useEffect(() => {
+    // Resets the dateRange filter when the filters.outbreak prop changes.
+    const dateRange =
+      filters.outbreak === "Ebola Outbreak"
+        ? ebolaInitialDateRange
+        : covidInitialDateRange;
+    return changeDateRange([dateRange.from, dateRange.to]);
+  }, [filters.outbreak, changeDateRange]);
 
   const handleRangeChange = (event, newRangeArray) => {
     // Only execute this block if the newRangeArray is different from the numberOfWeeks state.
@@ -26,7 +38,7 @@ const DateRange = (props) => {
       const toDateChange = 7 * (newRangeArray[1] - 72);
       newToDate.setDate(newToDate.getDate() + toDateChange);
 
-      props.changeDateRange([newFromDate, newToDate]);
+      changeDateRange([newFromDate, newToDate]);
       setSliderRange(newRangeArray);
     }
   };

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -34,18 +34,29 @@ const DateRange = ({ filters, changeDateRange }) => {
   }, [filters.outbreak, changeDateRange]);
 
   const handleRangeChange = (event, newRangeArray) => {
-    // Only execute this block if the newRangeArray is different from the numberOfWeeks state.
+    // Only execute this block if the newRangeArray is different from the sliderRange.
     if (sliderRange !== newRangeArray) {
+      // Determines which initialDateRange to use based on which outbreak is selected.
+      const initialDateRange =
+        filters.outbreak === "Ebola Outbreak"
+          ? ebolaInitialDateRange
+          : covidInitialDateRange;
+      // Gets the max value for the slider based on how many weeks are between the dates in the initialDateRange.
+      const maxSliderValue = getNumberOfWeeksBetweenDates(
+        initialDateRange.from,
+        initialDateRange.to
+      );
       // Here we are getting the new dateRange.from date value for the filters.
-      let newFromDate = new Date(ebolaInitialDateRange.from);
+      let newFromDate = new Date(initialDateRange.from);
       const fromDateChange = 7 * newRangeArray[0];
       newFromDate.setDate(newFromDate.getDate() + fromDateChange);
       // Here we are getting the new dateRange.to date value for the filters.
-      let newToDate = new Date(ebolaInitialDateRange.to);
-      const toDateChange = 7 * (newRangeArray[1] - 72);
+      let newToDate = new Date(initialDateRange.to);
+      const toDateChange = 7 * (newRangeArray[1] - maxSliderValue);
       newToDate.setDate(newToDate.getDate() + toDateChange);
-
+      // Changes the dateRange filter in the Redux state.
       changeDateRange([newFromDate, newToDate]);
+      // Sets the new sliderRange.
       setSliderRange(newRangeArray);
     }
   };

--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -13,27 +13,34 @@ import {
   DateRangeComponentContainer,
   DateRangeSliderContainer,
 } from "../styled-components/DateRangeComponentContainer";
+import { getNumberOfWeeksBetweenDates } from "../../utils/dateHelpers";
 
 const DateRange = ({ filters, changeDateRange }) => {
   const [sliderRange, setSliderRange] = useState([0, 72]);
 
+  // This useEffect updates the dateRange and sliderRange when the filters.outbreak prop changes.
   useEffect(() => {
-    // Resets the dateRange filter when the filters.outbreak prop changes.
     const dateRange =
       filters.outbreak === "Ebola Outbreak"
         ? ebolaInitialDateRange
         : covidInitialDateRange;
-    return changeDateRange([dateRange.from, dateRange.to]);
+    // Resets the dateRange filter.
+    changeDateRange([dateRange.from, dateRange.to]);
+    // Resets the values for the sliderRange.
+    setSliderRange([
+      0,
+      getNumberOfWeeksBetweenDates(dateRange.from, dateRange.to),
+    ]);
   }, [filters.outbreak, changeDateRange]);
 
   const handleRangeChange = (event, newRangeArray) => {
     // Only execute this block if the newRangeArray is different from the numberOfWeeks state.
     if (sliderRange !== newRangeArray) {
-      // Here we are getting the new dateRange.from date value for the filters
+      // Here we are getting the new dateRange.from date value for the filters.
       let newFromDate = new Date(ebolaInitialDateRange.from);
       const fromDateChange = 7 * newRangeArray[0];
       newFromDate.setDate(newFromDate.getDate() + fromDateChange);
-      // Here we are getting the new dateRange.to date value for the filters
+      // Here we are getting the new dateRange.to date value for the filters.
       let newToDate = new Date(ebolaInitialDateRange.to);
       const toDateChange = 7 * (newRangeArray[1] - 72);
       newToDate.setDate(newToDate.getDate() + toDateChange);

--- a/src/constants/Countries.js
+++ b/src/constants/Countries.js
@@ -28,7 +28,7 @@ export const allCountries = [
   "Bhutan",
   "Bolivia",
   "Bonaire, Sint Eustatius and Saba",
-  "Bosnia and Herzegovina",
+  "Bosnia",
   "Botswana",
   "Bouvet Island",
   "Brazil",

--- a/src/constants/DateRanges.js
+++ b/src/constants/DateRanges.js
@@ -2,3 +2,8 @@ export const ebolaInitialDateRange = {
   from: new Date(2014, 9, 1),
   to: new Date(2016, 1, 20),
 };
+
+export const covidInitialDateRange = {
+  from: new Date(2020, 0, 20),
+  to: new Date(),
+};

--- a/src/utils/covidDataHelpers.js
+++ b/src/utils/covidDataHelpers.js
@@ -33,11 +33,13 @@ export const getCovidCaseCount = (covidData = [], filters) => {
     const selectedCountryDataObject = covidData.find(
       (dataObject) => dataObject.countryName === filters.country
     );
-    // Adds the case count for the last key in the 'cases' object for the selected country to the caseCount counter.
-    caseCount +=
-      selectedCountryDataObject.cases[
-        getLastObjectKey(selectedCountryDataObject.cases)
-      ];
+    if (selectedCountryDataObject) {
+      // If data for the country is found, adds the case count for the last key in the 'cases' object to the caseCount counter.
+      caseCount +=
+        selectedCountryDataObject.cases[
+          getLastObjectKey(selectedCountryDataObject.cases)
+        ];
+    }
   }
   return caseCount;
 };


### PR DESCRIPTION
![Screen Shot 2020-12-01 at 11 17 57 AM](https://user-images.githubusercontent.com/40768918/100766658-e1d05480-33c6-11eb-9620-b3d2d9171d97.png)

These changes update the `dateRange` filters in the Redux state when switching between ebola and covid outbreaks.

To test this: 

1) Pull dow this branch.
2) Run the app locally.
3) Select `COVID 19` from the outbreaks selector on the side bar. This will change the date range that is displayed in the side bar. If you then change back to the `Ebola Outbreak` option, this date range will change back to it's initial date range.