### PR TITLE
MRIID-42 Update Covid case counts in sidebar to use date filters

### DIFF
--- a/src/utils/__tests__/covidDataHelpers.test.js
+++ b/src/utils/__tests__/covidDataHelpers.test.js
@@ -2,7 +2,7 @@ import {
   parseCovidData,
   getLastObjectKey,
   getCovidCaseCount,
-  getCovidCountryCaseCountDataInDateRange,
+  getLatestCountryCountInDateRange,
 } from "../covidDataHelpers";
 import { testCovidData, testParsedCovidData } from "../testData";
 import { reduxInitialState } from "../../constants/CommonTestData";
@@ -58,16 +58,22 @@ describe("Tests for the getLastObjectKey helper function", () => {
   });
 });
 
-describe("Tests for getCovidCountryCaseCountInDateRange helper function", () => {
-  test("should only return data for dates between 11/27/20 and 11/30/20", () => {
-    const testDateRange = {
-      from: new Date(2020, 10, 27),
-      to: new Date(2020, 10, 30),
-    };
+describe("Tests for getLatestCountryCountInDateRange helper function", () => {
+  const testDateRange = {
+    from: new Date(2020, 10, 27),
+    to: new Date(2020, 10, 30),
+  };
+  test("should return 46215 which is the latest case count for Afghanistan", () => {
     const countryCaseCount = testParsedCovidData[0].cases;
     expect(
-      getCovidCountryCaseCountDataInDateRange(countryCaseCount, testDateRange)
-    ).toEqual({ "11/28/20": 40000, "11/29/20": 46215 });
+      getLatestCountryCountInDateRange(countryCaseCount, testDateRange)
+    ).toBe(46215);
+  });
+  test("should return 1763 which is the latest death count for Afghanistan", () => {
+    const countryDeathCount = testParsedCovidData[0].deaths;
+    expect(
+      getLatestCountryCountInDateRange(countryDeathCount, testDateRange)
+    ).toBe(1763);
   });
 });
 

--- a/src/utils/__tests__/covidDataHelpers.test.js
+++ b/src/utils/__tests__/covidDataHelpers.test.js
@@ -2,6 +2,7 @@ import {
   parseCovidData,
   getLastObjectKey,
   getCovidCaseCount,
+  getCovidCountryCaseCountDataInDateRange,
 } from "../covidDataHelpers";
 import { testCovidData, testParsedCovidData } from "../testData";
 import { reduxInitialState } from "../../constants/CommonTestData";
@@ -52,7 +53,21 @@ describe("Tests for the parseCovidData helper function", () => {
 
 describe("Tests for the getLastObjectKey helper function", () => {
   test("should return key of 11/29/20", () => {
-    expect(getLastObjectKey(testParsedCovidData[0].cases)).toEqual("11/29/20");
+    const countryCaseCount = testParsedCovidData[0].cases;
+    expect(getLastObjectKey(countryCaseCount)).toEqual("11/29/20");
+  });
+});
+
+describe("Tests for getCovidCountryCaseCountInDateRange helper function", () => {
+  test("should only return data for dates between 11/27/20 and 11/30/20", () => {
+    const testDateRange = {
+      from: new Date(2020, 10, 27),
+      to: new Date(2020, 10, 30),
+    };
+    const countryCaseCount = testParsedCovidData[0].cases;
+    expect(
+      getCovidCountryCaseCountDataInDateRange(countryCaseCount, testDateRange)
+    ).toEqual({ "11/28/20": 40000, "11/29/20": 46215 });
   });
 });
 

--- a/src/utils/__tests__/dateHelpers.test.js
+++ b/src/utils/__tests__/dateHelpers.test.js
@@ -38,10 +38,18 @@ describe("Tests for isDateWithinFiltersDateRange", () => {
       )
     ).toEqual(true);
   });
-  test("should return false because date is outside filterDates", () => {
+  test("should return false because 2013-10-13 is outside filterDates", () => {
     expect(
       isDateWithinFiltersDateRange(
         "2013-10-13",
+        reduxInitialState.filters.dateRange
+      )
+    ).toEqual(false);
+  });
+  test("should return false because 10/28/20 is outside filterDates", () => {
+    expect(
+      isDateWithinFiltersDateRange(
+        "10/28/20",
         reduxInitialState.filters.dateRange
       )
     ).toEqual(false);

--- a/src/utils/covidDataHelpers.js
+++ b/src/utils/covidDataHelpers.js
@@ -1,3 +1,5 @@
+import { isDateWithinFiltersDateRange } from "./dateHelpers";
+
 export const parseCovidData = (countriesCovidData = []) => {
   let parsedData = [];
   countriesCovidData.forEach((row) => {
@@ -20,13 +22,31 @@ export const getLastObjectKey = (dataObject) => {
   return objectKeys[objectKeys.length - 1];
 };
 
+export const getCovidCountryCaseCountDataInDateRange = (
+  countryCovidCaseData,
+  dateRange
+) => {
+  let dataInDateRange = {};
+  Object.keys(countryCovidCaseData).forEach((weekKey) => {
+    if (isDateWithinFiltersDateRange(weekKey, dateRange)) {
+      dataInDateRange[weekKey] = countryCovidCaseData[weekKey];
+    }
+  });
+  return dataInDateRange;
+};
+
 export const getCovidCaseCount = (covidData = [], filters) => {
   let caseCount = 0;
   if (filters.country === "All") {
     // Loops through each country in the covidData array.
     covidData.forEach((countryData) => {
+      const countryCasesInDateRange = getCovidCountryCaseCountDataInDateRange(
+        countryData.cases,
+        filters.dateRange
+      );
+      const lastDateKey = getLastObjectKey(countryCasesInDateRange);
       // Adds the case count for the last key in the 'cases' object for each country to the caseCount counter.
-      caseCount += countryData.cases[getLastObjectKey(countryData.cases)];
+      caseCount += countryCasesInDateRange[lastDateKey];
     });
   } else {
     // Finds the data object for the country selected in filters.country.
@@ -35,10 +55,12 @@ export const getCovidCaseCount = (covidData = [], filters) => {
     );
     if (selectedCountryDataObject) {
       // If data for the country is found, adds the case count for the last key in the 'cases' object to the caseCount counter.
-      caseCount +=
-        selectedCountryDataObject.cases[
-          getLastObjectKey(selectedCountryDataObject.cases)
-        ];
+      const countryCasesInDateRange = getCovidCountryCaseCountDataInDateRange(
+        selectedCountryDataObject.cases,
+        filters.dateRange
+      );
+      const lastDateKey = getLastObjectKey(countryCasesInDateRange);
+      caseCount += countryCasesInDateRange[lastDateKey];
     }
   }
   return caseCount;

--- a/src/utils/covidDataHelpers.js
+++ b/src/utils/covidDataHelpers.js
@@ -28,6 +28,7 @@ export const getCovidCountryCaseCountDataInDateRange = (
 ) => {
   let dataInDateRange = {};
   Object.keys(countryCovidCaseData).forEach((weekKey) => {
+    // If the weekKey date is within the dateRange, add this data to the dataInDateRange object.
     if (isDateWithinFiltersDateRange(weekKey, dateRange)) {
       dataInDateRange[weekKey] = countryCovidCaseData[weekKey];
     }
@@ -63,5 +64,8 @@ export const getCovidCaseCount = (covidData = [], filters) => {
       caseCount += countryCasesInDateRange[lastDateKey];
     }
   }
-  return caseCount;
+  // Only returns the caseCount value if it is an integer. This ensures the caseCount returned is not NaN.
+  if (Number.isInteger(caseCount)) {
+    return caseCount;
+  }
 };

--- a/src/utils/covidDataHelpers.js
+++ b/src/utils/covidDataHelpers.js
@@ -22,18 +22,21 @@ export const getLastObjectKey = (dataObject) => {
   return objectKeys[objectKeys.length - 1];
 };
 
-export const getCovidCountryCaseCountDataInDateRange = (
-  countryCovidCaseData,
+export const getLatestCountryCountInDateRange = (
+  countryCovidData,
   dateRange
 ) => {
+  // 1. Add all of the data within the dateRange to the dataInDateRange object.
   let dataInDateRange = {};
-  Object.keys(countryCovidCaseData).forEach((weekKey) => {
-    // If the weekKey date is within the dateRange, add this data to the dataInDateRange object.
+  Object.keys(countryCovidData).forEach((weekKey) => {
     if (isDateWithinFiltersDateRange(weekKey, dateRange)) {
-      dataInDateRange[weekKey] = countryCovidCaseData[weekKey];
+      dataInDateRange[weekKey] = countryCovidData[weekKey];
     }
   });
-  return dataInDateRange;
+  // 2. Find the last key in the dataInDateRange object.
+  const lastDateKey = getLastObjectKey(dataInDateRange);
+  // 3. Return the last value from the dataInDateRange object.
+  return dataInDateRange[lastDateKey];
 };
 
 export const getCovidCaseCount = (covidData = [], filters) => {
@@ -41,27 +44,23 @@ export const getCovidCaseCount = (covidData = [], filters) => {
   if (filters.country === "All") {
     // Loops through each country in the covidData array.
     covidData.forEach((countryData) => {
-      const countryCasesInDateRange = getCovidCountryCaseCountDataInDateRange(
+      // Adds the latest case count for each country to the caseCount.
+      caseCount += getLatestCountryCountInDateRange(
         countryData.cases,
         filters.dateRange
       );
-      const lastDateKey = getLastObjectKey(countryCasesInDateRange);
-      // Adds the case count for the last key in the 'cases' object for each country to the caseCount counter.
-      caseCount += countryCasesInDateRange[lastDateKey];
     });
   } else {
     // Finds the data object for the country selected in filters.country.
     const selectedCountryDataObject = covidData.find(
       (dataObject) => dataObject.countryName === filters.country
     );
+    // If data for the country is found, get the latest case count the country and set it to the caseCount variable.
     if (selectedCountryDataObject) {
-      // If data for the country is found, adds the case count for the last key in the 'cases' object to the caseCount counter.
-      const countryCasesInDateRange = getCovidCountryCaseCountDataInDateRange(
+      caseCount = getLatestCountryCountInDateRange(
         selectedCountryDataObject.cases,
         filters.dateRange
       );
-      const lastDateKey = getLastObjectKey(countryCasesInDateRange);
-      caseCount += countryCasesInDateRange[lastDateKey];
     }
   }
   // Only returns the caseCount value if it is an integer. This ensures the caseCount returned is not NaN.

--- a/src/utils/testData.js
+++ b/src/utils/testData.js
@@ -533,12 +533,12 @@ export const testCovidData = [
 export const testParsedCovidData = [
   {
     countryName: "Afghanistan",
-    cases: { "11/28/20": 40000, "11/29/20": 46215 },
+    cases: { "10/28/20": 30000, "11/28/20": 40000, "11/29/20": 46215 },
     deaths: { "11/29/20": 1763 },
   },
   {
     countryName: "Zimbabwe",
-    cases: { "11/28/20": 40000, "11/29/20": 46215 },
+    cases: { "10/28/20": 30000, "11/28/20": 40000, "11/29/20": 46215 },
     deaths: { "11/29/20": 1763 },
   },
 ];


### PR DESCRIPTION
![Screen Shot 2020-12-02 at 9 14 42 AM](https://user-images.githubusercontent.com/40768918/100883867-d2144700-347e-11eb-8ab7-6dad230d1a2c.png)

This can be tested by: 

1) Pulling down this branch.
2) Running the app locally.
3) Selecting `COVID 19` in the Sidebar.
4) Updating the date range with the sate slider. This will update the case count that is shown in the sidebar.