### PR TITLE
MRIID-43 Update snapshot map legend with covid data

### DIFF
--- a/src/components/SnapshotMapCaseCountLegend/index.js
+++ b/src/components/SnapshotMapCaseCountLegend/index.js
@@ -7,7 +7,7 @@ import {
   getSnapshotColor,
   getSnapshotProjectionsColor,
 } from "../../utils/snapshotMapHelpers";
-import { getEbolaCountriesCaseCounts } from "../../utils/ebolaDataHelpers";
+import { getCountriesEbolaCaseCounts } from "../../utils/ebolaDataHelpers";
 import { getCountriesCovidCaseCounts } from "../../utils/covidDataHelpers";
 import {
   MapLegendWrapperSnapshot,
@@ -22,7 +22,7 @@ const SnapshotMapCaseCountLegend = ({ ebolaData, covidData, filters }) => {
   // Getting the number of case counts for each country.
   // We need this to get the max value for the legend.
   const countriesCaseCounts = ebolaOutbreakSelected
-    ? getEbolaCountriesCaseCounts(ebolaData, filters)
+    ? getCountriesEbolaCaseCounts(ebolaData, filters)
     : getCountriesCovidCaseCounts(covidData, filters);
 
   const legendHeader = filters.projection

--- a/src/components/SnapshotMapCaseCountLegend/index.js
+++ b/src/components/SnapshotMapCaseCountLegend/index.js
@@ -3,36 +3,42 @@ import { connect } from "react-redux";
 import MapLegendLevel from "../MapLegendLevel";
 import {
   getEbolaScale,
+  getCovidScale,
   getSnapshotColor,
   getSnapshotProjectionsColor,
 } from "../../utils/snapshotMapHelpers";
 import { getEbolaCountriesCaseCounts } from "../../utils/ebolaDataHelpers";
+import { getCountriesCovidCaseCounts } from "../../utils/covidDataHelpers";
 import {
   MapLegendWrapperSnapshot,
   MapLegendItemsWrapper,
 } from "../styled-components/MapLegendWrappers";
 import { BlockDropshadow } from "../styled-components/Block";
 
-const SnapshotMapCaseCountLegend = ({ ebolaData, filters }) => {
+const SnapshotMapCaseCountLegend = ({ ebolaData, covidData, filters }) => {
+  // Determines whether the ebola outbreak is selected.
+  const ebolaOutbreakSelected = filters.outbreak === "Ebola Outbreak";
+
   // Getting the number of case counts for each country.
   // We need this to get the max value for the legend.
-  const countriesEbolaCaseCounts = getEbolaCountriesCaseCounts(
-    ebolaData,
-    filters
-  );
+  const countriesCaseCounts = ebolaOutbreakSelected
+    ? getEbolaCountriesCaseCounts(ebolaData, filters)
+    : getCountriesCovidCaseCounts(covidData, filters);
 
   const legendHeader = filters.projection
     ? "Total outbreak projections"
     : "Case counts";
 
   const renderLegendLevels = () => {
-    const scale = getEbolaScale(countriesEbolaCaseCounts);
+    const scale = ebolaOutbreakSelected
+      ? getEbolaScale(countriesCaseCounts)
+      : getCovidScale(countriesCaseCounts);
     // We want to render 10 levels for the legend.
     const numberOfLevels = 9;
     const levels = [];
     for (let i = 0; i <= numberOfLevels; i++) {
       let value = i / numberOfLevels;
-      // If the projections are turned on, we want to use the projections colors.
+      // If the projections are enabled, we want to use the projections colors.
       // Else, use the regular snapshot colors.
       const color = filters.projection
         ? getSnapshotProjectionsColor(value)
@@ -61,6 +67,7 @@ const SnapshotMapCaseCountLegend = ({ ebolaData, filters }) => {
 
 const mapStateToProps = (state) => ({
   ebolaData: state.ebola.ebolaData.data,
+  covidData: state.covid.covidData.data,
   filters: state.filters,
 });
 

--- a/src/utils/__tests__/ebolaDataHelpers.test.js
+++ b/src/utils/__tests__/ebolaDataHelpers.test.js
@@ -1,5 +1,5 @@
 import {
-  getEbolaCountriesCaseCounts,
+  getCountriesEbolaCaseCounts,
   getEbolaCaseCount,
   getAllFutureProjectedCasesCount,
   getCountryFutureProjectedCasesCount,
@@ -15,10 +15,10 @@ import {
 
 import { reduxInitialState } from "../../constants/CommonTestData";
 
-describe("Tests for getEbolaCountriesCaseCounts", () => {
+describe("Tests for getCountriesEbolaCaseCounts", () => {
   test("should return data in expected format", () => {
     expect(
-      getEbolaCountriesCaseCounts(
+      getCountriesEbolaCaseCounts(
         allCountriesEbolaData,
         reduxInitialState.filters
       )
@@ -26,7 +26,7 @@ describe("Tests for getEbolaCountriesCaseCounts", () => {
   });
   test("should only count data within the date range in the filters", () => {
     expect(
-      getEbolaCountriesCaseCounts(
+      getCountriesEbolaCaseCounts(
         allCountriesEbolaDataLiberiaOutOfDateRange,
         reduxInitialState.filters
       )
@@ -38,7 +38,7 @@ describe("Tests for getEbolaCountriesCaseCounts", () => {
       filters: { ...reduxInitialState.filters, projection: true },
     };
     expect(
-      getEbolaCountriesCaseCounts(
+      getCountriesEbolaCaseCounts(
         allCountriesEbolaData,
         projectionsEnabledState.filters
       )

--- a/src/utils/ebolaDataHelpers.js
+++ b/src/utils/ebolaDataHelpers.js
@@ -35,7 +35,7 @@ export const prepareEbolaData = (csvData) => {
 };
 
 // This gets the country case counts for the Snapshot map.
-export const getEbolaCountriesCaseCounts = (ebolaData, filters) => {
+export const getCountriesEbolaCaseCounts = (ebolaData, filters) => {
   let countryCaseCount = {
     Guinea: 0,
     Liberia: 0,
@@ -69,7 +69,7 @@ export const getEbolaCountriesCaseCounts = (ebolaData, filters) => {
 // This gets the case count for the Sidebar
 export const getEbolaCaseCount = (diseaseData, filters) => {
   let diseaseCaseCount = 0;
-  const ebolaCountriesCaseCounts = getEbolaCountriesCaseCounts(
+  const ebolaCountriesCaseCounts = getCountriesEbolaCaseCounts(
     diseaseData,
     filters
   );

--- a/src/utils/snapshotMapHelpers.js
+++ b/src/utils/snapshotMapHelpers.js
@@ -1,4 +1,4 @@
-import { getEbolaCountriesCaseCounts } from "./ebolaDataHelpers";
+import { getCountriesEbolaCaseCounts } from "./ebolaDataHelpers";
 import { getCountriesCovidCaseCounts } from "./covidDataHelpers";
 import { ebolaOutbreakCountries, allCountries } from "../constants/Countries";
 
@@ -112,7 +112,7 @@ export const getSnapshotProjectionsColor = (caseCountValue) => {
 export const getEbolaFillColorsDictionary = (ebolaData, filters) => {
   let colorsDictionary = {};
   // Get the case count for the 3 ebolaOutbreakCountries.
-  const ebolaCountriesCaseCounts = getEbolaCountriesCaseCounts(
+  const ebolaCountriesCaseCounts = getCountriesEbolaCaseCounts(
     ebolaData,
     filters
   );
@@ -171,7 +171,7 @@ export const getCountryFillColor = (
 export const getCountryToolTipContent = (diseaseData, filters, countryName) => {
   let countryCaseCount;
   if (filters.outbreak === "Ebola Outbreak") {
-    const ebolaCountriesCaseCounts = getEbolaCountriesCaseCounts(
+    const ebolaCountriesCaseCounts = getCountriesEbolaCaseCounts(
       diseaseData,
       filters
     );


### PR DESCRIPTION
![Screen Shot 2020-12-03 at 3 34 20 PM](https://user-images.githubusercontent.com/40768918/101085146-066e2d00-357d-11eb-8e4c-136427683b52.png)

Can be tested by:

1) Pulling down this branch.
2) Running the app locally.
3) Selecting `COVID 19` in the Sidebar. You should see the COVID case count data in the Snapshot map legend.