### PR TITLE
Fixed issue with Burma/Myanmar country selection options

### DIFF
--- a/src/actions/covid.js
+++ b/src/actions/covid.js
@@ -7,7 +7,8 @@ export const fetchCovidData = () => (dispatch) => {
   dispatch({
     type: types.FETCH_COVID_DATA_REQUEST,
   });
-  const countriesString = allCountries.join();
+  const countries = ["Burma", ...allCountries];
+  const countriesString = countries.join();
 
   return axios
     .get(

--- a/src/constants/Countries.js
+++ b/src/constants/Countries.js
@@ -29,7 +29,6 @@ export const allCountries = [
   "Brunei",
   "Bulgaria",
   "Burkina Faso",
-  "Burma",
   "Burundi",
   "Cabo Verde",
   "Cambodia",


### PR DESCRIPTION
Fixed an issue where both `Burma` and `Myanmar` were options on the sidebar. This is because while the country is now called `Myanmar`, the John's Hopkins data has it listed as `Burma` so I had to send `Burma` as a parameter to fetch the data. 

I removed `Burma` from the sidebar, but I am still sending it as a parameter to fetch Covid data from: https://disease.sh/docs/#/COVID-19%3A%20JHUCSSE/get_v3_covid_19_historical__country

