### PR TITLE
Bug/reset covid date range

### DIFF
--- a/src/components/DateRange/index.js
+++ b/src/components/DateRange/index.js
@@ -6,41 +6,37 @@ import { Slider } from "@material-ui/core";
 import Timespan from "../Timespan";
 import ProjectionsToggle from "../ProjectionsToggle";
 import {
-  ebolaInitialDateRange,
-  covidInitialDateRange,
-} from "../../constants/DateRanges";
-import {
   DateRangeComponentContainer,
   DateRangeSliderContainer,
 } from "../styled-components/DateRangeComponentContainer";
-import { getNumberOfWeeksBetweenDates } from "../../utils/dateHelpers";
+import {
+  getNumberOfWeeksBetweenDates,
+  getOutbreakInitialDateRange,
+} from "../../utils/dateHelpers";
 
 const DateRange = ({ filters, changeDateRange }) => {
   const [sliderRange, setSliderRange] = useState([0, 72]);
+  const initialDateRange = getOutbreakInitialDateRange(filters.outbreak);
 
   // This useEffect updates the dateRange and sliderRange when the filters.outbreak prop changes.
   useEffect(() => {
-    const dateRange =
-      filters.outbreak === "Ebola Outbreak"
-        ? ebolaInitialDateRange
-        : covidInitialDateRange;
     // Resets the dateRange filter.
-    changeDateRange([dateRange.from, dateRange.to]);
+    changeDateRange([initialDateRange.from, initialDateRange.to]);
     // Resets the values for the sliderRange.
     setSliderRange([
       0,
-      getNumberOfWeeksBetweenDates(dateRange.from, dateRange.to),
+      getNumberOfWeeksBetweenDates(initialDateRange.from, initialDateRange.to),
     ]);
-  }, [filters.outbreak, changeDateRange]);
+  }, [
+    filters.outbreak,
+    changeDateRange,
+    initialDateRange.from,
+    initialDateRange.to,
+  ]);
 
   const handleRangeChange = (event, newRangeArray) => {
     // Only execute this block if the newRangeArray is different from the sliderRange.
     if (sliderRange !== newRangeArray) {
-      // Determines which initialDateRange to use based on which outbreak is selected.
-      const initialDateRange =
-        filters.outbreak === "Ebola Outbreak"
-          ? ebolaInitialDateRange
-          : covidInitialDateRange;
       // Gets the max value for the slider based on how many weeks are between the dates in the initialDateRange.
       const maxSliderValue = getNumberOfWeeksBetweenDates(
         initialDateRange.from,

--- a/src/components/Timespan/index.js
+++ b/src/components/Timespan/index.js
@@ -4,21 +4,16 @@ import dayjs from "dayjs";
 
 import { bindActionCreators } from "redux";
 import { changeDateRange } from "../../actions/filters";
-import { getNumberOfWeeksBetweenDates } from "../../utils/dateHelpers";
+import {
+  getNumberOfWeeksBetweenDates,
+  getOutbreakInitialDateRange,
+} from "../../utils/dateHelpers";
 import { TimespanButtonsWrapper } from "../styled-components/TimespanButtonsWrapper";
 import { Button, ButtonLink } from "../styled-components/Button";
-import {
-  ebolaInitialDateRange,
-  covidInitialDateRange,
-} from "../../constants/DateRanges";
 
 const Timespan = ({ changeDateRange, updateSliderRange, outbreak }) => {
   //  Determines which initialDateRange to use depending on which outbreak is selected.
-  const initialDateRange =
-    outbreak === "Ebola Outbreak"
-      ? ebolaInitialDateRange
-      : covidInitialDateRange;
-
+  const initialDateRange = getOutbreakInitialDateRange(outbreak);
   const updateDateRange = (number = 0, unitOfTime) => {
     // Uses the dayjs library to add units of time to the 'from' date in the initial date range.
     const newToDate = new Date(

--- a/src/components/Timespan/index.js
+++ b/src/components/Timespan/index.js
@@ -9,28 +9,25 @@ import { TimespanButtonsWrapper } from "../styled-components/TimespanButtonsWrap
 import { Button, ButtonLink } from "../styled-components/Button";
 import { ebolaInitialDateRange } from "../../constants/DateRanges";
 
-const Timespan = (props) => {
+const Timespan = ({ changeDateRange, updateSliderRange }) => {
   const updateDateRange = (number = 0, unitOfTime) => {
     // Uses the dayjs library to add units of time to the 'from' date in the initial date range.
     const newToDate = new Date(
       dayjs(ebolaInitialDateRange.from).add(number, unitOfTime).format()
     );
     // Updates the date range filter in the redux state.
-    props.changeDateRange([ebolaInitialDateRange.from, newToDate]);
+    changeDateRange([ebolaInitialDateRange.from, newToDate]);
     // Updates the sliderRange in the DateRange component.
-    props.updateSliderRange([
+    updateSliderRange([
       0,
       getNumberOfWeeksBetweenDates(ebolaInitialDateRange.from, newToDate),
     ]);
   };
   const resetDateRange = () => {
     //  Reset the date range filter in the redux state to it's initial state.
-    props.changeDateRange([
-      ebolaInitialDateRange.from,
-      ebolaInitialDateRange.to,
-    ]);
+    changeDateRange([ebolaInitialDateRange.from, ebolaInitialDateRange.to]);
     //  Reset the sliderRange in the DateRange component.
-    props.updateSliderRange([
+    updateSliderRange([
       0,
       getNumberOfWeeksBetweenDates(
         ebolaInitialDateRange.from,

--- a/src/components/Timespan/index.js
+++ b/src/components/Timespan/index.js
@@ -7,32 +7,38 @@ import { changeDateRange } from "../../actions/filters";
 import { getNumberOfWeeksBetweenDates } from "../../utils/dateHelpers";
 import { TimespanButtonsWrapper } from "../styled-components/TimespanButtonsWrapper";
 import { Button, ButtonLink } from "../styled-components/Button";
-import { ebolaInitialDateRange } from "../../constants/DateRanges";
+import {
+  ebolaInitialDateRange,
+  covidInitialDateRange,
+} from "../../constants/DateRanges";
 
-const Timespan = ({ changeDateRange, updateSliderRange }) => {
+const Timespan = ({ changeDateRange, updateSliderRange, outbreak }) => {
+  //  Determines which initialDateRange to use depending on which outbreak is selected.
+  const initialDateRange =
+    outbreak === "Ebola Outbreak"
+      ? ebolaInitialDateRange
+      : covidInitialDateRange;
+
   const updateDateRange = (number = 0, unitOfTime) => {
     // Uses the dayjs library to add units of time to the 'from' date in the initial date range.
     const newToDate = new Date(
-      dayjs(ebolaInitialDateRange.from).add(number, unitOfTime).format()
+      dayjs(initialDateRange.from).add(number, unitOfTime).format()
     );
     // Updates the date range filter in the redux state.
-    changeDateRange([ebolaInitialDateRange.from, newToDate]);
+    changeDateRange([initialDateRange.from, newToDate]);
     // Updates the sliderRange in the DateRange component.
     updateSliderRange([
       0,
-      getNumberOfWeeksBetweenDates(ebolaInitialDateRange.from, newToDate),
+      getNumberOfWeeksBetweenDates(initialDateRange.from, newToDate),
     ]);
   };
   const resetDateRange = () => {
     //  Reset the date range filter in the redux state to it's initial state.
-    changeDateRange([ebolaInitialDateRange.from, ebolaInitialDateRange.to]);
+    changeDateRange([initialDateRange.from, initialDateRange.to]);
     //  Reset the sliderRange in the DateRange component.
     updateSliderRange([
       0,
-      getNumberOfWeeksBetweenDates(
-        ebolaInitialDateRange.from,
-        ebolaInitialDateRange.to
-      ),
+      getNumberOfWeeksBetweenDates(initialDateRange.from, initialDateRange.to),
     ]);
   };
   return (
@@ -56,4 +62,8 @@ const mapDispatchToProps = (dispatch) =>
     dispatch
   );
 
-export default connect(null, mapDispatchToProps)(Timespan);
+const mapStateToProps = (state) => ({
+  outbreak: state.filters.outbreak,
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Timespan);

--- a/src/utils/__tests__/dateHelpers.test.js
+++ b/src/utils/__tests__/dateHelpers.test.js
@@ -2,8 +2,12 @@ import {
   getNumberOfWeeksBetweenDates,
   isDateWithinFiltersDateRange,
   getWeeklyDateObjectKeys,
+  getOutbreakInitialDateRange,
 } from "../dateHelpers";
-import { ebolaInitialDateRange } from "../../constants/DateRanges";
+import {
+  ebolaInitialDateRange,
+  covidInitialDateRange,
+} from "../../constants/DateRanges";
 import { reduxInitialState } from "../../constants/CommonTestData";
 import { testObjectDateKeys } from "../testData";
 
@@ -66,5 +70,18 @@ describe("Tests for getWeeklyDateObjectKeys", () => {
       "2/5/20",
       "2/12/20",
     ]);
+  });
+});
+
+describe("Tests for getOutbreakInitialDateRange", () => {
+  test("should return ebolaInitialDateRange", () => {
+    expect(getOutbreakInitialDateRange("Ebola Outbreak")).toEqual(
+      ebolaInitialDateRange
+    );
+  });
+  test("should return covidInitialDateRange", () => {
+    expect(getOutbreakInitialDateRange("COVID 19")).toEqual(
+      covidInitialDateRange
+    );
   });
 });

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -1,4 +1,8 @@
 import dayjs from "dayjs";
+import {
+  ebolaInitialDateRange,
+  covidInitialDateRange,
+} from "../constants/DateRanges";
 
 export const getNumberOfWeeksBetweenDates = (firstDate, secondDate) => {
   const startDate = dayjs(firstDate);
@@ -16,3 +20,9 @@ export const isDateWithinFiltersDateRange = (weekDateString, dateRange) => {
 // Returns an array of keys where the dates are 7 days apart. This is to get the weekly data.
 export const getWeeklyDateObjectKeys = (dataObject) =>
   Object.keys(dataObject).filter((value, index) => index % 7 === 0);
+
+//  Returns the initial date range depending on which outbreak is selected.
+export const getOutbreakInitialDateRange = (outbreakSelected) =>
+  outbreakSelected === "Ebola Outbreak"
+    ? ebolaInitialDateRange
+    : covidInitialDateRange;


### PR DESCRIPTION
![Screen Shot 2020-12-11 at 11 22 31 AM](https://user-images.githubusercontent.com/40768918/101928072-2c11bc80-3ba3-11eb-83aa-bb76299ea6cb.png)

Fixed bug when resetting the date range by clicking on 'Reset' or 'Max' on the timespan. 

Before this fix, no matter which `outbreak` was selected, clicking on these buttons would reset to date range to the `ebolaInitialDateRange`.

This should now work as expected. 