### PR TITLE
MRIID-47 Showing daily Covid case counts in chart

### DIFF
--- a/src/utils/__tests__/chartDataHelpers.test.js
+++ b/src/utils/__tests__/chartDataHelpers.test.js
@@ -5,7 +5,6 @@ import {
   getSelectedCountryChartData,
   getWeekProjectionData,
   getCovidDataForCharts,
-  returnLastSevenDaysDataCount,
 } from "../chartDataHelpers";
 import {
   testGuineaData,
@@ -17,8 +16,9 @@ import {
 import {
   covidAllCountriesFilters,
   covidAfghanistanFilters,
-  testCountryCovidCaseCounts,
   testTwoCountryCovidCaseCounts,
+  expectedAllCountriesChartData,
+  expectedOneCountryChartData,
 } from "../testData/covidTestData";
 import { reduxInitialState } from "../../constants/CommonTestData";
 import dayjs from "dayjs";
@@ -161,21 +161,7 @@ test("returns all country data in expected format", () => {
       testTwoCountryCovidCaseCounts,
       covidAllCountriesFilters
     )
-  ).toEqual([
-    [
-      {
-        type: "date",
-        label: "Date",
-      },
-      {
-        type: "number",
-        label: "COVID-19 Cases",
-      },
-    ],
-    [new Date("2/24/20"), 2],
-    [new Date("3/2/20"), 14],
-    [new Date("3/9/20"), 60],
-  ]);
+  ).toEqual(expectedAllCountriesChartData);
 });
 
 test("returns specific country data in expected format", () => {
@@ -184,21 +170,7 @@ test("returns specific country data in expected format", () => {
       testTwoCountryCovidCaseCounts,
       covidAfghanistanFilters
     )
-  ).toEqual([
-    [
-      {
-        type: "date",
-        label: "Date",
-      },
-      {
-        type: "number",
-        label: "COVID-19 Cases",
-      },
-    ],
-    [new Date("2/24/20"), 1],
-    [new Date("3/2/20"), 7],
-    [new Date("3/9/20"), 30],
-  ]);
+  ).toEqual(expectedOneCountryChartData);
 });
 
 describe("Tests for getCovidDataForCharts", () => {
@@ -208,21 +180,7 @@ describe("Tests for getCovidDataForCharts", () => {
         testTwoCountryCovidCaseCounts,
         covidAllCountriesFilters
       )
-    ).toEqual([
-      [
-        {
-          type: "date",
-          label: "Date",
-        },
-        {
-          type: "number",
-          label: "COVID-19 Cases",
-        },
-      ],
-      [new Date("2/24/20"), 2],
-      [new Date("3/2/20"), 14],
-      [new Date("3/9/20"), 60],
-    ]);
+    ).toEqual(expectedAllCountriesChartData);
   });
   test("returns specific country data in expected format", () => {
     expect(
@@ -230,42 +188,6 @@ describe("Tests for getCovidDataForCharts", () => {
         testTwoCountryCovidCaseCounts,
         covidAfghanistanFilters
       )
-    ).toEqual([
-      [
-        {
-          type: "date",
-          label: "Date",
-        },
-        {
-          type: "number",
-          label: "COVID-19 Cases",
-        },
-      ],
-      [new Date("2/24/20"), 1],
-      [new Date("3/2/20"), 7],
-      [new Date("3/9/20"), 30],
-    ]);
-  });
-});
-
-describe("Tests for returnLastSevenDaysDataCount", () => {
-  const covidDataDateKeys = Object.keys(testCountryCovidCaseCounts.countryData);
-  test("should return 203", () => {
-    expect(
-      returnLastSevenDaysDataCount(
-        testCountryCovidCaseCounts.countryData,
-        covidDataDateKeys,
-        "11/23/20"
-      )
-    ).toBe(203);
-  });
-  test("should return 1509", () => {
-    expect(
-      returnLastSevenDaysDataCount(
-        testCountryCovidCaseCounts.countryData,
-        covidDataDateKeys,
-        "11/30/20"
-      )
-    ).toBe(1509);
+    ).toEqual(expectedOneCountryChartData);
   });
 });

--- a/src/utils/__tests__/dateHelpers.test.js
+++ b/src/utils/__tests__/dateHelpers.test.js
@@ -1,7 +1,6 @@
 import {
   getNumberOfWeeksBetweenDates,
   isDateWithinFiltersDateRange,
-  getWeeklyDateObjectKeys,
   getOutbreakInitialDateRange,
 } from "../dateHelpers";
 import {
@@ -9,7 +8,6 @@ import {
   covidInitialDateRange,
 } from "../../constants/DateRanges";
 import { reduxInitialState } from "../../constants/CommonTestData";
-import { testObjectDateKeys } from "../testData/covidTestData";
 
 describe("tests for the getNumberOfWeeksBetweenDates helper function", () => {
   test("using date strings, the dates should be 2 weeks apart", () => {
@@ -59,17 +57,6 @@ describe("Tests for isDateWithinFiltersDateRange", () => {
         reduxInitialState.filters.dateRange
       )
     ).toEqual(false);
-  });
-});
-
-describe("Tests for getWeeklyDateObjectKeys", () => {
-  test("should return array of date keys which are 7 days apart", () => {
-    expect(getWeeklyDateObjectKeys(testObjectDateKeys)).toEqual([
-      "1/22/20",
-      "1/29/20",
-      "2/5/20",
-      "2/12/20",
-    ]);
   });
 });
 

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -17,10 +17,6 @@ export const isDateWithinFiltersDateRange = (weekDateString, dateRange) => {
   return dateValue > dateRange.from && dateValue < dateRange.to;
 };
 
-// Returns an array of keys where the dates are 7 days apart. This is to get the weekly data.
-export const getWeeklyDateObjectKeys = (dataObject) =>
-  Object.keys(dataObject).filter((value, index) => index % 7 === 0);
-
 //  Returns the initial date range depending on which outbreak is selected.
 export const getOutbreakInitialDateRange = (outbreakSelected) =>
   outbreakSelected === "Ebola Outbreak"

--- a/src/utils/testData/covidTestData.js
+++ b/src/utils/testData/covidTestData.js
@@ -27,31 +27,6 @@ export const testParsedCovidData = [
   },
 ];
 
-export const testObjectDateKeys = {
-  "1/22/20": 0,
-  "1/23/20": 0,
-  "1/24/20": 0,
-  "1/25/20": 0,
-  "1/26/20": 0,
-  "1/27/20": 0,
-  "1/28/20": 0,
-  "1/29/20": 0,
-  "1/30/20": 0,
-  "1/31/20": 0,
-  "2/1/20": 0,
-  "2/2/20": 0,
-  "2/3/20": 0,
-  "2/4/20": 0,
-  "2/5/20": 0,
-  "2/6/20": 0,
-  "2/7/20": 0,
-  "2/8/20": 0,
-  "2/9/20": 0,
-  "2/10/20": 0,
-  "2/11/20": 0,
-  "2/12/20": 0,
-};
-
 export const testCountryCovidCaseCounts = {
   countryName: "Afghanistan",
   countryData: {
@@ -120,6 +95,62 @@ export const testTwoCountryCovidCaseCounts = [
       "3/9/20": 7,
     },
   },
+];
+
+export const expectedAllCountriesChartData = [
+  [
+    {
+      type: "date",
+      label: "Date",
+    },
+    {
+      type: "number",
+      label: "COVID-19 Cases",
+    },
+  ],
+  [new Date("2/24/20"), 2],
+  [new Date("2/25/20"), 2],
+  [new Date("2/26/20"), 2],
+  [new Date("2/27/20"), 2],
+  [new Date("2/28/20"), 2],
+  [new Date("2/29/20"), 2],
+  [new Date("3/01/20"), 2],
+  [new Date("3/02/20"), 2],
+  [new Date("3/03/20"), 4],
+  [new Date("3/04/20"), 8],
+  [new Date("3/05/20"), 8],
+  [new Date("3/06/20"), 8],
+  [new Date("3/07/20"), 8],
+  [new Date("3/08/20"), 10],
+  [new Date("3/09/20"), 14],
+];
+
+export const expectedOneCountryChartData = [
+  [
+    {
+      type: "date",
+      label: "Date",
+    },
+    {
+      type: "number",
+      label: "COVID-19 Cases",
+    },
+  ],
+  [new Date("2/24/20"), 1],
+  [new Date("2/25/20"), 1],
+  [new Date("2/26/20"), 1],
+  [new Date("2/27/20"), 1],
+  [new Date("2/28/20"), 1],
+  [new Date("2/29/20"), 1],
+  [new Date("3/01/20"), 1],
+  [new Date("3/02/20"), 1],
+  [new Date("3/03/20"), 2],
+  [new Date("3/04/20"), 4],
+  [new Date("3/05/20"), 4],
+  [new Date("3/06/20"), 4],
+  [new Date("3/07/20"), 4],
+  [new Date("3/08/20"), 5],
+  [new Date("3/09/20"), 7],
 ];
 
 export const covidCaseCountsDictionary = {


### PR DESCRIPTION
![Screen Shot 2021-01-06 at 9 15 19 AM](https://user-images.githubusercontent.com/40768918/103778049-b52fde00-4fff-11eb-8689-535ad3d3df20.png)

Per Sangeeta's request, updated the Covid chart data to display daily rather than weekly data. 