### PR TITLE
Refactor select component

### DIFF
--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -3,16 +3,12 @@ import React from "react";
 import * as Styled from "./styles";
 
 const Select = (props) => {
-  const renderOptions = (array) => {
-    const selectOptions = array.map(function (value, index) {
-      return (
-        <Styled.StyledMenuItem key={`select-option-${index}`} value={value}>
-          {value}
-        </Styled.StyledMenuItem>
-      );
-    });
-    return selectOptions;
-  };
+  const renderOptions = (optionsArray = []) =>
+    optionsArray.map((value, index) => (
+      <Styled.StyledMenuItem key={`select-option-${index}`} value={value}>
+        {value}
+      </Styled.StyledMenuItem>
+    ));
 
   return (
     <>

--- a/src/components/Select/index.js
+++ b/src/components/Select/index.js
@@ -2,7 +2,13 @@ import React from "react";
 
 import * as Styled from "./styles";
 
-const Select = (props) => {
+const Select = ({
+  name,
+  value,
+  changeFunction,
+  optionsCurrent,
+  optionsPast,
+}) => {
   const renderOptions = (optionsArray = []) =>
     optionsArray.map((value, index) => (
       <Styled.StyledMenuItem key={`select-option-${index}`} value={value}>
@@ -12,11 +18,11 @@ const Select = (props) => {
 
   return (
     <>
-      <Styled.InputLabel>{props.name}</Styled.InputLabel>
+      <Styled.InputLabel>{name}</Styled.InputLabel>
       <Styled.StyledMuiSelect
-        name={props.name}
-        value={props.value}
-        onChange={props.changeFunction}
+        name={name}
+        value={value}
+        onChange={changeFunction}
         MenuProps={{
           anchorOrigin: {
             vertical: "bottom",
@@ -32,9 +38,9 @@ const Select = (props) => {
         <Styled.StyledListSubheader>
           Current Outbreaks
         </Styled.StyledListSubheader>
-        {renderOptions(props.optionsCurrent)}
+        {renderOptions(optionsCurrent)}
         <Styled.StyledListSubheader>Past Outbreaks</Styled.StyledListSubheader>
-        {renderOptions(props.optionsPast)}
+        {renderOptions(optionsPast)}
       </Styled.StyledMuiSelect>
     </>
   );


### PR DESCRIPTION
Cleaned up the `props` for the `Select` component and also refactored the `renderOptions()` component method. This component should function the same as before. 

You can also run `npm test`, then hit the `a` key to run all the tests. All tests should pass. 